### PR TITLE
Use correct(?) error variable for test.

### DIFF
--- a/busybox/libbb/remove_file.c
+++ b/busybox/libbb/remove_file.c
@@ -16,7 +16,7 @@ int FAST_FUNC remove_file(const char *path, int flags)
 	struct stat path_stat;
 
 	if (lstat(path, &path_stat) < 0) {
-		if (bb_errno != ENOENT) {
+		if (errno != ENOENT) {
 			bb_perror_msg("can't stat '%s'", path);
 			return -1;
 		}


### PR DESCRIPTION
This code is using 'bb_errno', but that is a pointer, so the compiler produces a warning (which is how I noticed it).
I suspect it should use errno (as the rest of the ofgwrite code does).  But it's possible(?) that it should be *bb_errno, although nothing else uses that - beyond it being declared.

I don't have any example of the code actually being used...