### PR TITLE
Support for linux as bootloader multiboot based on kexec

### DIFF
--- a/ofgwrite.c
+++ b/ofgwrite.c
@@ -1122,7 +1122,7 @@ void find_kernel_rootfs_device()
 	// get kernel/rootfs from cmdline
 	readProcCmdline();
 
-	if (!found_kernel_device || !found_rootfs_device) // Both kernel and rootfs needs to be found. Otherwise ignore found devices
+	if ((!found_kernel_device || !found_rootfs_device) && strcmp(kexec_mode, "1") != 0) // Both kernel and rootfs needs to be found. Otherwise ignore found devices
 	{
 		found_kernel_device = 0;
 		found_rootfs_device = 0;

--- a/ofgwrite.c
+++ b/ofgwrite.c
@@ -1181,7 +1181,7 @@ void find_kernel_rootfs_device()
 	{
 		found_kernel_device = 1;
 		kernel_flash_mode = TARBZ2;
-		sprintf(kernel_device, "/oldroot_remount/linuxrootfs%d/boot/kernel_auto.bin", multiboot_partition);
+		sprintf(kernel_device, "/oldroot_remount/linuxrootfs%d/zImage", multiboot_partition);
 		my_printf("Using %s as kernel device\n", kernel_device);
 		found_rootfs_device = 1;
 		rootfs_flash_mode = TARBZ2;

--- a/ofgwrite.c
+++ b/ofgwrite.c
@@ -1183,6 +1183,11 @@ void find_kernel_rootfs_device()
 		kernel_flash_mode = TARBZ2;
 		sprintf(kernel_device, "/oldroot_remount/linuxrootfs%d/zImage", multiboot_partition);
 		my_printf("Using %s as kernel device\n", kernel_device);
+	}
+
+	// use kexec rootfs mode
+	if (!found_rootfs_device && strcmp(kexec_mode, "1") == 0)
+	{
 		found_rootfs_device = 1;
 		rootfs_flash_mode = TARBZ2;
 		strcpy(rootfs_device, current_rootfs_device);


### PR DESCRIPTION
Since the kernel for each slot is stored into the slot itself, is required to invert rootfs and kernel flashing.

We developed this multiboot solution for vuplus boxes but can work on other boxes with few changes.