### PR TITLE
change lazy umount to regular umount due to data corruption when rebooting after multiboot slot flash

### DIFF
--- a/ofgwrite.c
+++ b/ofgwrite.c
@@ -2054,7 +2054,9 @@ int main(int argc, char *argv[])
 		sleep(1);
 		if (!stop_e2_needed)
 		{
-			ret = umount2("/oldroot_remount/", MNT_DETACH);
+			ret = umount("/oldroot_remount/");	// blocking umount to flush dirty pages before reboot
+			if (ret)
+				umount2("/oldroot_remount/", MNT_DETACH);	// fallback if mountpoint is busy
 			ret = rmdir("/oldroot_remount/");
 			ret = umount2("/newroot/", MNT_DETACH);
 			ret = rmdir("/newroot/");


### PR DESCRIPTION
This pr fixes the problem that the linuxrootfsx is being corrupted during reboot of the box after an image has been flashed into a multiboot slot.
right after flashing the image linuxrootfsx is still ok and contains about 150mb of extracted image data. after reboot linuxrootfsx is corrupt and only contains about 28mb. box does not boot anymore with the corrupted linuxrootfsx.
analysis revealed that the problem is caused by the lazy umount before shutting down the box. the lazy umount obviously doesn't flush all the data in memory fast enough before shutdown.
changing the lazy umount into a regular umount fixes the problem.