### PR TITLE
android: detect SD auto-boot for kernel filename

### DIFF
--- a/ofgwrite.c
+++ b/ofgwrite.c
@@ -109,7 +109,7 @@ enum RootfsTypeEnum rootfs_type;
 int stop_e2_needed = 1;
 int chkroot_mode = 0;
 
-const char ofgwrite_version[] = "4.8.0";
+const char ofgwrite_version[] = "4.8.1";
 
 struct struct_mountlist
 {
@@ -2014,8 +2014,8 @@ int main(int argc, char *argv[])
 					dreamcard = 0;
 				}
 
-				if (strcmp(label, "DREAMCARD\n") != 0) {
-					my_printf("Info: The device label does not match 'dreamcard'\n");
+				if (strcmp(label, "DREAMCARD\n") != 0 && strcmp(label, "DREAMBOOT\n") != 0) {
+					my_printf("Info: The device label does not match 'dreamcard' or 'dreamboot'\n");
 					dreamcard = 0;
 				}
 				if (dreamcard) {
@@ -2027,15 +2027,21 @@ int main(int argc, char *argv[])
 						rmdir(dreamcard_mount);
 						return EXIT_FAILURE;
 					}
-					size_t length = strlen(rootfs_device);
-					int kernelnr = (length > 0) ? rootfs_device[length - 1] - '0' : -1;
-					if (kernelnr < 0 || kernelnr > 9) {
-						my_printf("Error: Invalid kernel number\n");
-						rmdir(dreamcard_mount);
-						return EXIT_FAILURE;
-					}
 					char filename[50];
-					snprintf(filename, sizeof(filename), "/dreamcard/kernel%d.img", kernelnr);
+					//SD auto-boot variant: u-boot.bin + kernel.img present -> write kernel.img
+					if (access("/dreamcard/u-boot.bin", F_OK) == 0
+					 && access("/dreamcard/kernel.img", F_OK) == 0) {
+						snprintf(filename, sizeof(filename), "/dreamcard/kernel.img");
+					} else {
+						size_t length = strlen(rootfs_device);
+						int kernelnr = (length > 0) ? rootfs_device[length - 1] - '0' : -1;
+						if (kernelnr < 0 || kernelnr > 9) {
+							my_printf("Error: Invalid kernel number\n");
+							rmdir(dreamcard_mount);
+							return EXIT_FAILURE;
+						}
+						snprintf(filename, sizeof(filename), "/dreamcard/kernel%d.img", kernelnr);
+					}
 					my_printf("start generate %s image on %s\n", filename, dreamcard_device);
 					generate_boot_image(filename);
 					sync();


### PR DESCRIPTION
When flashing to an SD card with -a (Android boot image), ofgwrite previously assumed the multiboot slot convention: filename always kernel<N>.img where N is the last digit of rootfs_device, gated by LABEL=DREAMCARD.

This breaks SD auto-boot setups where the SD-FAT contains a u-boot.bin plus a fixed kernel.img (no partition number) that U-Boot loads via hijacked autoexec.img. Those setups commonly use LABEL=DREAMBOOT and expect the kernel file to be named kernel.img.

Two minimal changes:
- Accept DREAMBOOT label in addition to DREAMCARD.
- After mounting SD-FAT, if u-boot.bin + kernel.img are both present, write kernel.img (no number). Otherwise keep the existing kernel<N>.img path for multiboot slots.

Multiboot-slot behavior is unchanged.